### PR TITLE
Autofix: ba61e33e-e4eb-4643-8573-b73a2ba0afda

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ groups =
     test
     astral: astral
 commands =
-    pytest {posargs: --doctest-modules --cov=hdate --cov-report=term-missing --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests}
+    pytest {posargs: --doctest-modules --cov=hdate --cov-report=term-missing --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy --timeout=300 tests}
 
 [testenv:no_astral]
 description = Test without optional astral dependency


### PR DESCRIPTION
Modified the pytest command in tox.ini to include a timeout option. This should prevent the test suite from hanging indefinitely on Python 3.11+.